### PR TITLE
build: fix incorrect LDFLAGS on certain systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ else
 	CFLAGS+= -O2
 endif
 
-LDLIBS=-lncursesw -lpthread
+LDLIBS=$(shell ncursesw6-config --libs) -lpthread
 
 #.c files all subdirectories
 C_SOURCE= $(wildcard $(SRCDIR)/*.c) $(wildcard $(SRCDIR)/*/*.c)


### PR DESCRIPTION
In 0.6.0, the Makefile contains static LDFLAGS that may work on most systems, but on certain setups (e.g. Gentoo) cause build failures. This PR replaces the LDFLAGS declaration with a call to `ncursesw6-config --libs`, which is guaranteed to produce the correct set of LDFLAGS for all ncurses installations.